### PR TITLE
Update for site_location, and routed_networks, and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,14 @@
 
 ## Features
 - fixed typo found in Variables.tf 
+
+## 0.0.5 (2025-06-27)
+
+### Features 
+- Added Site_Location, Site location is now derived from AWS Region 
+- Added Routed Networks - Routed Networks can now be provided and auto routed to the TGW. 
+- Updated Variables for New Features and to simplify the code 
+- Removed native_network_range, this is now derived from subnet_range_lan 
+- Updated Readme
+- Cleaned up and reorganized code 
+- Implemented Version constraints on modules and providers

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Reference the resources as input variables with the following syntax:
 </details>
 
 ## NOTE
+- Site Location for Cato Socket is automatically inferred based on the region being deployed, however this can be overridden if necessary.
 - For help with finding exact sytax to match site location for city, state_name, country_name and timezone, please refer to the [cato_siteLocation data source](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/siteLocation).
 - For help with finding a license id to assign, please refer to the [cato_licensingInfo data source](https://registry.terraform.io/providers/catonetworks/cato/latest/docs/data-sources/licensingInfo).
 - Creation of the Default Route in the Transit Gateway Route-Table is Feature-Flagged, to allow for planned migration.  Defaults to False (Don't Build)
@@ -68,13 +69,13 @@ provider "cato" {
 
 // AWS VPC and Virtual Socket Module
 module "vsocket-aws-vpc-tgw" {
-  source                         = "catonetworks/vsocket-aws-tgw/cato"
+  source                          = "catonetworks/vsocket-aws-tgw/cato"
+  version                         = "0.0.5"
   vpc_id                          = null
   internet_gateway_id             = null 
   ingress_cidr_blocks             = ["0.0.0.0/0"]
   key_pair                        = "Your-Keypair-here"
   vpc_network_range               = "10.1.0.0/22"
-  native_network_range            = "10.1.0.0/16"
   subnet_range_mgmt               = "10.1.1.0/25"
   subnet_range_wan                = "10.1.1.128/25"
   subnet_range_lan                = "10.1.2.0/25"
@@ -87,12 +88,15 @@ module "vsocket-aws-vpc-tgw" {
   tgw_route_table_id              = "tgw-rtb-01234567890abcdef"
   site_description                = "Your Cato site desc here"
   build_default_tgw_route_to_cato = false # False = Don't Build the 0.0.0.0/0 Route In The TGW RT
-  site_location = {
-    city         = "New York City"
-    country_code = "US"
-    state_code   = "US-NY" ## Optional - for countries with states"
-    timezone     = "America/New_York"
+  # Site location derived from AWS Region 
+
+  # Example Networks to be routed through to AWS
+  routed_networks = {
+    "Peered-VPC-1" = "10.100.1.0/24"
+    "App-VPC"      = "10.100.3.0/24"
+    "DatabaseVPC"  = "10.100.2.0/24"
   }
+  
   tags = {
     Environment = "Production"
     Owner = "Operations Team"
@@ -126,21 +130,22 @@ Apache 2 Licensed. See [LICENSE](https://github.com/catonetworks/terraform-cato-
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_cato"></a> [cato](#requirement\_cato) | ~> 0.0.23 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.98.0 |
+| <a name="requirement_cato"></a> [cato](#requirement\_cato) | ~> 0.0.27 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.98.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cato_deployment"></a> [cato\_deployment](#module\_cato\_deployment) | catonetworks/vsocket-aws-vpc/cato | ~> 0.0.9 |
+| <a name="module_cato_deployment"></a> [cato\_deployment](#module\_cato\_deployment) | ../terraform-cato-vsocket-aws-vpc | n/a |
 
 ## Resources
 
@@ -167,9 +172,10 @@ Apache 2 Licensed. See [LICENSE](https://github.com/catonetworks/terraform-cato-
 | <a name="input_license_bw"></a> [license\_bw](#input\_license\_bw) | The license bandwidth number for the cato site, specifying bandwidth ONLY applies for pooled licenses.  For a standard site license that is not pooled, leave this value null. Must be a number greater than 0 and an increment of 10. | `string` | `null` | no |
 | <a name="input_license_id"></a> [license\_id](#input\_license\_id) | The license ID for the Cato vSocket of license type CATO\_SITE, CATO\_SSE\_SITE, CATO\_PB, CATO\_PB\_SSE.  Example License ID value: 'abcde123-abcd-1234-abcd-abcde1234567'.  Note that licenses are for commercial accounts, and not supported for trial accounts. | `string` | `null` | no |
 | <a name="input_mgmt_eni_ip"></a> [mgmt\_eni\_ip](#input\_mgmt\_eni\_ip) | Choose an IP Address within the Management Subnet. You CANNOT use the first four assignable IP addresses within the subnet as it's reserved for the AWS virtual router interface. The accepted input format is X.X.X.X | `string` | n/a | yes |
-| <a name="input_native_network_range"></a> [native\_network\_range](#input\_native\_network\_range) | Choose a unique range for your new vsocket site that does not conflict with the rest of your Wide Area Network.<br/>    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_routed_networks"></a> [routed\_networks](#input\_routed\_networks) | A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.<br/>  Example: <br/>  routed\_networks = {<br/>  "Peered-VNET-1" = "10.100.1.0/24"<br/>  "On-Prem-Network" = "192.168.50.0/24"<br/>  "Management-Subnet" = "10.100.2.0/25"<br/>  } | `map(string)` | `{}` | no |
 | <a name="input_site_description"></a> [site\_description](#input\_site\_description) | Description of the vsocket site | `string` | n/a | yes |
-| <a name="input_site_location"></a> [site\_location](#input\_site\_location) | n/a | <pre>object({<br/>    city         = string<br/>    country_code = string<br/>    state_code   = string<br/>    timezone     = string<br/>  })</pre> | n/a | yes |
+| <a name="input_site_location"></a> [site\_location](#input\_site\_location) | Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly. | <pre>object({<br/>    city         = string<br/>    country_code = string<br/>    state_code   = string<br/>    timezone     = string<br/>  })</pre> | <pre>{<br/>  "city": null,<br/>  "country_code": null,<br/>  "state_code": null,<br/>  "timezone": null<br/>}</pre> | no |
 | <a name="input_site_name"></a> [site\_name](#input\_site\_name) | Name of the vsocket site | `string` | n/a | yes |
 | <a name="input_site_type"></a> [site\_type](#input\_site\_type) | The type of the site | `string` | `"CLOUD_DC"` | no |
 | <a name="input_subnet_range_lan"></a> [subnet\_range\_lan](#input\_subnet\_range\_lan) | Choose a range within the VPC to use as the Private/LAN subnet. This subnet will host the target LAN interface of the vSocket so resources in the VPC (or AWS Region) can route to the Cato Cloud.<br/>    The minimum subnet length to support High Availability is /29.<br/>    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ provider "cato" {
 // AWS VPC and Virtual Socket Module
 module "vsocket-aws-vpc-tgw" {
   source                          = "catonetworks/vsocket-aws-tgw/cato"
-  version                         = "0.0.5"
+  version                         = ">= 0.0.5"
   vpc_id                          = null
   internet_gateway_id             = null 
   ingress_cidr_blocks             = ["0.0.0.0/0"]

--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,23 @@
 module "cato_deployment" {
   source               = "catonetworks/vsocket-aws-vpc/cato"
-  version              = "~> 0.0.9"
-  vpc_id               = var.vpc_id
-  ingress_cidr_blocks  = var.ingress_cidr_blocks
-  key_pair             = var.key_pair
-  subnet_range_mgmt    = var.subnet_range_mgmt
-  subnet_range_wan     = var.subnet_range_wan
-  subnet_range_lan     = var.subnet_range_lan
-  mgmt_eni_ip          = var.mgmt_eni_ip
-  wan_eni_ip           = var.wan_eni_ip
-  lan_eni_ip           = var.lan_eni_ip
-  vpc_network_range    = var.vpc_network_range
-  native_network_range = var.native_network_range
-  site_name            = var.site_name
-  site_description     = var.site_description
-  site_location        = var.site_location
-  tags                 = var.tags
+  version              = "~> 0.0.10"
+  vpc_id              = var.vpc_id
+  ingress_cidr_blocks = var.ingress_cidr_blocks
+  key_pair            = var.key_pair
+  subnet_range_mgmt   = var.subnet_range_mgmt
+  subnet_range_wan    = var.subnet_range_wan
+  subnet_range_lan    = var.subnet_range_lan
+  mgmt_eni_ip         = var.mgmt_eni_ip
+  wan_eni_ip          = var.wan_eni_ip
+  lan_eni_ip          = var.lan_eni_ip
+  vpc_network_range   = var.vpc_network_range
+  site_name           = var.site_name
+  site_description    = var.site_description
+  site_location       = var.site_location
+  tags                = var.tags
+  region              = var.region
+  routed_networks     = var.routed_networks
+
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "cato_vpc" {
@@ -27,8 +29,9 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "cato_vpc" {
 }
 
 resource "aws_route" "cato_private_to_tgw" {
+  for_each               = var.routed_networks
   route_table_id         = module.cato_deployment.lan_subnet_route_table_id
-  destination_cidr_block = var.native_network_range
+  destination_cidr_block = each.value
   transit_gateway_id     = var.tgw_id
   depends_on             = [null_resource.tgw_stabilizer]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "cato_deployment" {
   source               = "catonetworks/vsocket-aws-vpc/cato"
-  version              = "~> 0.0.10"
+  version              = ">= 0.0.10"
   vpc_id              = var.vpc_id
   ingress_cidr_blocks = var.ingress_cidr_blocks
   key_pair            = var.key_pair

--- a/variables.tf
+++ b/variables.tf
@@ -9,14 +9,6 @@ variable "site_description" {
   type        = string
 }
 
-variable "native_network_range" {
-  type        = string
-  description = <<EOT
-  	Choose a unique range for your new vsocket site that does not conflict with the rest of your Wide Area Network.
-    The accepted input format is Standard CIDR Notation, e.g. X.X.X.X/X
-	EOT
-}
-
 variable "vpc_network_range" {
   type        = string
   description = <<EOT
@@ -36,12 +28,19 @@ variable "site_type" {
 }
 
 variable "site_location" {
+  description = "Site location which is used by the Cato Socket to connect to the closest Cato PoP. If not specified, the location will be derived from the Azure region dynamicaly."
   type = object({
     city         = string
     country_code = string
     state_code   = string
     timezone     = string
   })
+  default = {
+    city         = null
+    country_code = null
+    state_code   = null ## Optional - for countries with states
+    timezone     = null
+  }
 }
 
 ## VPC Module Variables
@@ -168,4 +167,23 @@ variable "build_default_tgw_route_to_cato" {
   description = "Whether or Not to Build a default route in TGW Route Table to point at cato"
   type        = bool
   default     = false
+}
+
+variable "region" {
+  description = "AWS Region"
+  type        = string
+}
+
+variable "routed_networks" {
+  description = <<EOF
+  A map of routed networks to be accessed behind the vSocket site. The key is the network name and the value is the CIDR range.
+  Example: 
+  routed_networks = {
+  "Peered-VNET-1" = "10.100.1.0/24"
+  "On-Prem-Network" = "192.168.50.0/24"
+  "Management-Subnet" = "10.100.2.0/25"
+  }
+  EOF
+  type        = map(string)
+  default     = {} # Default to an empty map instead of null.
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,12 +1,13 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.98.0"
     }
     cato = {
       source  = "registry.terraform.io/catonetworks/cato"
-      version = "~> 0.0.23"
+      version = "~> 0.0.27"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.5"
 }


### PR DESCRIPTION
## 0.0.5 (2025-06-27)

### Features 
- Added Site_Location, Site location is now derived from AWS Region 
- Added Routed Networks - Routed Networks can now be provided and auto routed to the TGW. 
- Updated Variables for New Features and to simplify the code 
- Removed native_network_range, this is now derived from subnet_range_lan 
- Updated Readme
- Cleaned up and reorganized code 
- Implemented Version constraints on modules and providers